### PR TITLE
IS-857: manage preCommit data with DB

### DIFF
--- a/common/db/bucket.go
+++ b/common/db/bucket.go
@@ -19,6 +19,9 @@ const (
 	// For calculation result DB
 	PrefixCalcResult BucketID         = ""
 
+	// For claim DB
+	PrefixClaim BucketID              = ""
+
 	// For global DB
 
 	// Information for management

--- a/core/context_test.go
+++ b/core/context_test.go
@@ -43,13 +43,13 @@ func TestContext_NewContext(t *testing.T) {
 	assert.Equal(t, dbCount, len(ctx.DB.Account0))
 	assert.Equal(t, dbCount, len(ctx.DB.Account1))
 	assert.NotNil(t, ctx.DB.calcResult)
+	assert.NotNil(t, ctx.DB.preCommit)
 	assert.NotNil(t, ctx.DB.claim)
 
 	assert.NotNil(t, ctx.GV)
 	assert.NotNil(t, ctx.PRep)
 	assert.NotNil(t, ctx.PRepCandidates)
 	assert.NotNil(t, ctx.calculateStatus)
-	assert.NotNil(t, ctx.preCommit)
 }
 
 func TestContext_UpdateGovernanceVariable(t *testing.T) {
@@ -356,6 +356,13 @@ func TestContext_GetCalcDBList(t *testing.T) {
 	assert.Equal(t, ctx.DB.Account1, ctx.DB.GetCalcDBList())
 	ctx.DB.info.QueryDBIsZero = false
 	assert.Equal(t, ctx.DB.Account0, ctx.DB.GetCalcDBList())
+}
+
+func TestContext_GetPreCommitDB(t *testing.T) {
+	ctx := initTest(1)
+	defer finalizeTest()
+
+	assert.Equal(t, ctx.DB.preCommit, ctx.DB.getPreCommitDB())
 }
 
 func TestContext_GetClaimDB(t *testing.T) {

--- a/core/db_claim.go
+++ b/core/db_claim.go
@@ -2,10 +2,14 @@ package core
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
+	"unsafe"
 
 	"github.com/icon-project/rewardcalculator/common"
 	"github.com/icon-project/rewardcalculator/common/codec"
+	"github.com/icon-project/rewardcalculator/common/db"
+	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
 type ClaimData struct {
@@ -13,10 +17,12 @@ type ClaimData struct {
 	IScore        common.HexInt
 }
 
+func (cd *ClaimData) equal(cmpData *ClaimData) bool {
+	return cd.IScore.Cmp(&cmpData.IScore.Int) == 0 && cd.BlockHeight == cmpData.BlockHeight
+}
+
 type Claim struct {
 	Address  common.Address
-	PrevData ClaimData
-	Confirmed bool
 	Data     ClaimData
 }
 
@@ -58,4 +64,225 @@ func NewClaimFromBytes(bs []byte) (*Claim, error) {
 	} else {
 		return claim, nil
 	}
+}
+
+type PreCommitData struct {
+	Confirmed bool
+	Claim
+}
+
+const blockHeightSize = 8
+const blockHashSize = 32
+const PreCommitIDSize = blockHeightSize + blockHashSize + common.AddressBytes
+
+type PreCommit struct {
+	BlockHeight uint64
+	BlockHash []byte
+	PreCommitData
+}
+
+func (pc *PreCommit) ID() []byte {
+	id := make([]byte, PreCommitIDSize)
+
+	bh := common.Uint64ToBytes(pc.BlockHeight)
+	copy(id[blockHeightSize - len(bh):], bh)
+	copy(id[blockHeightSize:], pc.BlockHash)
+	copy(id[blockHeightSize + blockHashSize:], pc.Address.Bytes())
+
+	return id
+}
+
+func (pc *PreCommit) Bytes() ([]byte, error) {
+	var bytes []byte
+	if bs, err := codec.MarshalToBytes(&pc.PreCommitData); err != nil {
+		return nil, err
+	} else {
+		bytes = bs
+	}
+	return bytes, nil
+}
+
+func (pc *PreCommit) String() string {
+	b, err := json.Marshal(pc)
+	if err != nil {
+		return "Can't covert Message to json"
+	}
+	return string(b)
+}
+
+func (pc *PreCommit) SetBytes(bs []byte) error {
+	_, err := codec.UnmarshalFromBytes(bs, &pc.PreCommitData)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func newPreCommit(blockHeight uint64, blockHash []byte, address common.Address) *PreCommit {
+	pc := new(PreCommit)
+
+	pc.BlockHeight = blockHeight
+	pc.BlockHash = make([]byte, blockHashSize)
+	copy(pc.BlockHash, blockHash)
+	pc.Address = address
+
+	return pc
+}
+
+func (pc *PreCommit) query(pcDB db.Database) bool {
+	bucket, _ := pcDB.GetBucket(db.PrefixClaim)
+	bs, _ := bucket.Get(pc.ID())
+	if bs != nil {
+		pc.SetBytes(bs)
+		return true
+	}
+
+	return false
+}
+
+func (pc *PreCommit) write(pcDB db.Database, iScore *common.HexInt) error {
+	bucket, _ := pcDB.GetBucket(db.PrefixClaim)
+	if iScore != nil {
+		pc.Data.BlockHeight = pc.BlockHeight
+		pc.Data.IScore.Set(&iScore.Int)
+	}
+	bs, err := pc.Bytes()
+	if err != nil {
+		return err
+	}
+
+	return bucket.Set(pc.ID(), bs)
+}
+
+func (pc *PreCommit) delete(pcDB db.Database) error {
+	bucket, _ := pcDB.GetBucket(db.PrefixClaim)
+	return bucket.Delete(pc.ID())
+}
+
+func (pc *PreCommit) commit(pcDB db.Database) error {
+	if pc.query(pcDB) == false {
+		return fmt.Errorf("no data to commit")
+	}
+	if pc.Confirmed == true {
+		return nil
+	}
+	pc.Confirmed = true
+	return pc.write(pcDB, nil)
+}
+
+func (pc *PreCommit) revert(pcDB db.Database) error {
+	if pc.query(pcDB) == false {
+		return fmt.Errorf("no data to commit")
+	}
+	if pc.Confirmed == true {
+		return nil
+	} else {
+		return pc.delete(pcDB)
+	}
+}
+
+func makeIteratorPrefix(blockHeight uint64, blockHash []byte) *util.Range {
+	blockHeightSize := int(unsafe.Sizeof(blockHeight))
+	bsSize := len(db.PrefixClaim) + blockHeightSize
+	if blockHash != nil {
+		bsSize += blockHashSize
+	}
+
+	bh := common.Uint64ToBytes(blockHeight)
+	bs := make([]byte, bsSize)
+
+	copy(bs, db.PrefixClaim)
+	copy(bs[len(db.PrefixClaim) + blockHeightSize - len(bh):], bh)
+	if blockHash != nil {
+		copy(bs[bsSize-blockHashSize:], blockHash)
+	}
+
+	return util.BytesPrefix(bs)
+}
+
+func flushPreCommit(pcDB db.Database, blockHeight uint64, blockHash []byte) error {
+	bucket, err := pcDB.GetBucket(db.PrefixClaim)
+	if err != nil {
+		return err
+
+	}
+	iter, err := pcDB.GetIterator()
+	if err != nil {
+		return err
+	}
+
+	// iterate & get keys to delete
+	keys := make([][]byte, 0)
+	prefix := makeIteratorPrefix(blockHeight, blockHash)
+	iter.New(prefix.Start, prefix.Limit)
+	for iter.Next() {
+		key := make([]byte, PreCommitIDSize)
+		copy(key, iter.Key()[len(db.PrefixClaim):])
+		keys = append(keys, key)
+	}
+	iter.Release()
+
+	err = iter.Error()
+	if err != nil {
+		return err
+	}
+
+	for _, key := range keys {
+		err = bucket.Delete(key)
+		if err != nil {
+			log.Printf("Failed to delete precommit data. %x", key)
+		}
+	}
+
+	return nil
+}
+
+func writePreCommitToClaimDB(pcDB db.Database, cDB db.Database, blockHeight uint64, blockHash []byte) error {
+	iter, err := pcDB.GetIterator()
+	if err != nil {
+		return err
+	}
+
+	// iterate & get values to write
+	var pc PreCommit
+	var claim Claim
+	bucket, _ := cDB.GetBucket(db.PrefixIScore)
+
+	prefix := makeIteratorPrefix(blockHeight, blockHash)
+	iter.New(prefix.Start, prefix.Limit)
+	for iter.Next() {
+		err = pc.SetBytes(iter.Value())
+		if err != nil {
+			break
+		}
+
+		claim = pc.Claim
+		if pc.Confirmed == false || claim.Data.IScore.Sign() == 0 {
+			continue
+		}
+		bs, _ := bucket.Get(claim.ID())
+		if nil != bs {
+			oldClaim, _ := NewClaimFromBytes(bs)
+			if claim.Data.BlockHeight <= oldClaim.Data.BlockHeight {
+				continue
+			}
+			// update with old I-Score
+			claim.Data.IScore.Add(&claim.Data.IScore.Int, &oldClaim.Data.IScore.Int)
+		}
+
+		// write to claim DB
+		bucket.Set(claim.ID(), claim.Bytes())
+	}
+	iter.Release()
+	if err != nil {
+		return err
+	}
+
+	err = iter.Error()
+	if err != nil {
+		return err
+	}
+
+	// flush precommit with block height
+	return flushPreCommit(pcDB, blockHeight, nil)
 }

--- a/core/db_claim_test.go
+++ b/core/db_claim_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/icon-project/rewardcalculator/common"
+	"github.com/icon-project/rewardcalculator/common/db"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,8 +37,7 @@ func TestDBClaim_BytesAndSetBytes(t *testing.T) {
 
 	claimNew.SetBytes(claim.Bytes())
 
-	assert.Equal(t, 0, claim.Data.IScore.Cmp(&claimNew.Data.IScore.Int))
-	assert.Equal(t, claim.Data.BlockHeight, claimNew.Data.BlockHeight)
+	assert.True(t, claim.Data.equal(&claimNew.Data))
 	assert.Equal(t, claim.Bytes(), claimNew.Bytes())
 }
 
@@ -51,4 +51,147 @@ func TestDBClaim_NewClaimFromBytes(t *testing.T) {
 	assert.Equal(t, 0, claim.Data.IScore.Cmp(&newClaim.Data.IScore.Int))
 	assert.Equal(t, claim.Data.BlockHeight, newClaim.Data.BlockHeight)
 	assert.Equal(t, claim.Bytes(), newClaim.Bytes())
+}
+
+var testBlockHash = []byte{0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef, 0x12, 0x34}
+
+func makePreCommit() *PreCommit {
+	claim := makeClaim()
+	preCommit := newPreCommit(claimBlockHeight, testBlockHash, claim.Address)
+	preCommit.Confirmed = false
+	preCommit.Data = claim.Data
+
+	return preCommit
+}
+
+func TestDBPreCommit_ID(t *testing.T) {
+	pc := makePreCommit()
+
+	id := pc.ID()
+
+	assert.Equal(t, 8 + 32 + 21, len(id))
+	assert.Equal(t, pc.BlockHeight, common.BytesToUint64(id[:8]))
+	assert.Equal(t, pc.BlockHash, id[8:8+32])
+	assert.Equal(t, pc.Address.Bytes(), id[8+32:])
+}
+
+func TestDBPreCommit_BytesAndSetBytes(t *testing.T) {
+	pc := makePreCommit()
+
+	var pcNew PreCommit
+
+	bs, err := pc.Bytes()
+	assert.Nil(t, err)
+
+	pcNew.SetBytes(bs)
+	bsNew, err := pcNew.Bytes()
+	assert.Nil(t, err)
+
+	assert.True(t, pc.Data.equal(&pcNew.Data))
+	assert.Equal(t, pc.Confirmed, pcNew.Confirmed)
+	assert.Equal(t, bs, bsNew)
+}
+
+func TestDBPreCommit_manage(t *testing.T) {
+	tests := [] struct {
+		blockHeight uint64
+		blockHash   []byte
+		address     *common.Address
+	}{
+		{blockHeight: 1, blockHash: []byte{0x01, 0x01}, address: common.NewAddressFromString("hx11")},
+		{blockHeight: 1, blockHash: []byte{0x01, 0x02}, address: common.NewAddressFromString("hx12")},
+	}
+	iScore := uint64(100)
+
+	ctx := initTest(1)
+	defer finalizeTest()
+
+	pcDB := ctx.DB.getPreCommitDB()
+
+	for i, tt := range tests {
+		pc := newPreCommit(tt.blockHeight, tt.blockHash, *tt.address)
+		// query no ent
+		assert.False(t, pc.query(pcDB))
+
+		// write
+		assert.Nil(t, pc.write(pcDB, common.NewHexIntFromUint64(iScore)))
+		assert.Equal(t, iScore, pc.Data.IScore.Uint64())
+		assert.False(t, pc.Confirmed)
+
+		// delete
+		assert.Nil(t, pc.delete(pcDB))
+		assert.False(t, pc.query(pcDB))
+
+		// rewrite to test commit
+		assert.Nil(t, pc.write(pcDB, common.NewHexIntFromUint64(iScore)))
+		assert.Equal(t, iScore, pc.Data.IScore.Uint64())
+
+		// commit and query confirmed preCommit
+		if i != len(tests) - 1 {
+			assert.Nil(t, pc.commit(pcDB))
+			assert.True(t, pc.Confirmed)
+			pc2 := newPreCommit(tt.blockHeight, tt.blockHash, *tt.address)
+			assert.True(t, pc2.query(pcDB))
+			assert.Equal(t, pc.Data.IScore.Uint64(), pc2.Data.IScore.Uint64())
+
+			// revert - confirmed precommit
+			assert.Nil(t, pc.revert(pcDB))
+			// can query
+			assert.True(t, pc.query(pcDB))
+		} else {
+			// do not commit last one
+
+			// commit - invalid blockHeight
+			pc = newPreCommit(tt.blockHeight + 1, tt.blockHash, *tt.address)
+			assert.Error(t, pc.commit(pcDB))
+
+			// commit - invalid blockHash
+			pc = newPreCommit(tt.blockHeight, nil, *tt.address)
+			assert.Error(t, pc.commit(pcDB))
+
+			// revert - invalid blockHeight
+			pc = newPreCommit(tt.blockHeight + 1, tt.blockHash, *tt.address)
+			assert.Error(t, pc.revert(pcDB))
+
+			// revert - invalid blockHash
+			pc = newPreCommit(tt.blockHeight, nil, *tt.address)
+			assert.Error(t, pc.revert(pcDB))
+
+			// revert
+			pc = newPreCommit(tt.blockHeight, tt.blockHash, *tt.address)
+			assert.Nil(t, pc.revert(pcDB))
+			// can't query
+			assert.False(t, pc.query(pcDB))
+
+			// rewrite to writePreCommitToClaimDB()
+			assert.Nil(t, pc.write(pcDB, common.NewHexIntFromUint64(iScore)))
+			assert.Equal(t, iScore, pc.Data.IScore.Uint64())
+			// can query
+			assert.True(t, pc.query(pcDB))
+		}
+	}
+
+	// write to claim DB with commit
+	cDB := ctx.DB.getClaimDB()
+	assert.Nil(t, writePreCommitToClaimDB(pcDB, cDB, tests[0].blockHeight, tests[0].blockHash))
+
+	// can't query commited precommit data
+	pc := newPreCommit(tests[0].blockHeight, tests[0].blockHash, *tests[0].address)
+	assert.False(t, pc.query(pcDB))
+
+	// can't query not commited precommit data
+	pc = newPreCommit(tests[1].blockHeight, tests[1].blockHash, *tests[1].address)
+	assert.False(t, pc.query(pcDB))
+
+	// read claim data from claimDB
+	bucket, _ := cDB.GetBucket(db.PrefixIScore)
+	bs, err := bucket.Get(tests[0].address.Bytes())
+	assert.NoError(t, err)
+	assert.NotNil(t, bs)
+
+	var claim Claim
+	claim.SetBytes(bs)
+
+	assert.Equal(t, tests[0].blockHeight, claim.Data.BlockHeight)
+	assert.Equal(t, iScore, claim.Data.IScore.Uint64())
 }

--- a/core/msg_claim_test.go
+++ b/core/msg_claim_test.go
@@ -8,135 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMsgClaim_PreCommit(t *testing.T) {
-	tests := [] struct {
-		blockHeight uint64
-		blockHash   []byte
-		address     *common.Address
-	}{
-		{blockHeight: 1, blockHash: []byte("1-1"), address: common.NewAddressFromString("hx11")},
-		{blockHeight: 1, blockHash: []byte("1-2"), address: common.NewAddressFromString("hx12")},
-	}
-
-	ctx := initTest(1)
-	defer finalizeTest()
-
-	var claim *Claim
-
-	// Query and add
-	for _, tt := range tests {
-		claim = ctx.preCommit.queryAndAdd(tt.blockHeight, tt.blockHash, *tt.address)
-		assert.Nil(t, claim)
-		claim = ctx.preCommit.queryAndAdd(tt.blockHeight, tt.blockHash, *tt.address)
-		assert.NotNil(t, claim)
-		assert.True(t, tt.address.Equal(&claim.Address))
-	}
-
-	// update - success
-	ia := new(IScoreAccount)
-	ia.Address = *tests[0].address
-	ia.BlockHeight = tests[0].blockHeight
-	ia.IScore.SetUint64(100)
-	err := ctx.preCommit.update(tests[0].blockHeight, tests[0].blockHash, ia)
-	assert.NoError(t, err)
-	claim = ctx.preCommit.queryAndAdd(tests[0].blockHeight, tests[0].blockHash, ia.Address)
-	assert.NotNil(t, claim)
-	assert.Equal(t, ia.IScore.Uint64(), claim.Data.IScore.Uint64())
-	assert.Equal(t, ia.BlockHeight, claim.Data.BlockHeight)
-	assert.False(t, claim.Confirmed)
-
-	// update - invalid block height
-	err = ctx.preCommit.update(0, tests[0].blockHash, ia)
-	assert.Error(t, err)
-
-	// update - invalid address
-	ia.Address = *common.NewAddressFromString("hx22")
-	err = ctx.preCommit.update(tests[0].blockHeight, tests[0].blockHash, ia)
-	assert.Error(t, err)
-	ia.Address = *tests[0].address
-
-	// revert
-	err = ctx.preCommit.revert(tests[0].blockHeight, tests[0].blockHash, ia.Address)
-	assert.NoError(t, err)
-	claim = ctx.preCommit.queryAndAdd(tests[0].blockHeight, tests[0].blockHash, ia.Address)
-	assert.NotNil(t, claim)
-	assert.Equal(t, uint64(0), claim.Data.IScore.Uint64())
-	assert.Equal(t, uint64(0), claim.Data.BlockHeight)
-	assert.True(t, claim.Confirmed)
-
-	// revert - invalid block height
-	err = ctx.preCommit.revert(0, tests[0].blockHash, ia.Address)
-	assert.Error(t, err)
-
-	// revert - invalid address
-	err = ctx.preCommit.revert(tests[0].blockHeight, tests[0].blockHash, *common.NewAddressFromString("hx22"))
-	assert.Error(t, err)
-
-	// delete
-	ret := ctx.preCommit.delete(tests[0].blockHeight, tests[0].blockHash, *tests[0].address)
-	assert.True(t, ret)
-
-	// delete - invalid claim
-	ret = ctx.preCommit.delete(tests[0].blockHeight, tests[0].blockHash, *tests[0].address)
-	assert.False(t, ret)
-
-	// flush precommitData
-	pcLen := len(ctx.preCommit.dataList)
-	ctx.preCommit.flush(tests[1].blockHeight, tests[1].blockHash)
-	assert.Equal(t, pcLen - 1, len(ctx.preCommit.dataList))
-
-	// make data for write test
-	ia.Address = *tests[0].address
-	for _, tt := range tests {
-		ctx.preCommit.queryAndAdd(tt.blockHeight, tt.blockHash, *tt.address)
-		err = ctx.preCommit.update(tt.blockHeight, tt.blockHash, ia)
-	}
-
-	// write to claim DB without commit - there is no data to write
-	ctx.preCommit.writeClaimToDB(ctx, tests[0].blockHeight, tests[0].blockHash)
-	claimDB := ctx.DB.getClaimDB()
-	bucket, _ := claimDB.GetBucket(db.PrefixIScore)
-	bs, err := bucket.Get(tests[0].address.Bytes())
-	assert.NoError(t, err)
-	assert.Nil(t, bs)
-
-	// make data for commit & write test
-	ia.Address = *tests[0].address
-	for _, tt := range tests {
-		ctx.preCommit.queryAndAdd(tt.blockHeight, tt.blockHash, *tt.address)
-		err = ctx.preCommit.update(tt.blockHeight, tt.blockHash, ia)
-	}
-
-	// commit
-	err = ctx.preCommit.commit(tests[0].blockHeight, tests[0].blockHash, ia.Address)
-	assert.NoError(t, err)
-	claim = ctx.preCommit.queryAndAdd(tests[0].blockHeight, tests[0].blockHash, ia.Address)
-	assert.NotNil(t, claim)
-	assert.Equal(t, uint64(0), claim.PrevData.IScore.Uint64())
-	assert.Equal(t, uint64(0), claim.PrevData.BlockHeight)
-	assert.True(t, claim.Confirmed)
-
-	// commit - block height
-	err = ctx.preCommit.commit(0, tests[0].blockHash, ia.Address)
-	assert.Error(t, err)
-
-	// commit - invalid address
-	err = ctx.preCommit.commit(tests[0].blockHeight, tests[0].blockHash, *common.NewAddressFromString("hx22"))
-	assert.Error(t, err)
-
-	// write to claim DB
-	ctx.preCommit.writeClaimToDB(ctx, tests[0].blockHeight, tests[0].blockHash)
-	claimDB = ctx.DB.getClaimDB()
-	bucket, _ = claimDB.GetBucket(db.PrefixIScore)
-	bs, err = bucket.Get(tests[0].address.Bytes())
-	assert.NoError(t, err)
-	assert.NotNil(t, bs)
-
-	claim.SetBytes(bs)
-	assert.Equal(t, tests[0].blockHeight, claim.Data.BlockHeight)
-	assert.Equal(t, 0, claim.Data.IScore.Int.Cmp(&ia.IScore.Int))
-	assert.Equal(t, 0, len(ctx.preCommit.dataList))
-}
 
 func TestMsgClaim_DoClaim(t *testing.T) {
 	const (
@@ -193,11 +64,12 @@ func TestMsgClaim_DoClaim(t *testing.T) {
 
 	// already claimed in current block
 	blockHeight, iScore = DoClaim(ctx, &claim)
-	assert.Equal(t, dbContent1.BlockHeight, blockHeight)
+	assert.Equal(t, claim.BlockHeight, blockHeight)
 	assert.Nil(t, iScore)
 
 	// write claim to DB
-	ctx.preCommit.writeClaimToDB(ctx, claim.BlockHeight, claim.BlockHash)
+	//ctx.preCommit.writeClaimToDB(ctx, claim.BlockHeight, claim.BlockHash)
+	writePreCommitToClaimDB(ctx.DB.getPreCommitDB(), ctx.DB.getClaimDB(), claim.BlockHeight, claim.BlockHash)
 
 	// invalid address
 	blockHeight, iScore = DoClaim(ctx, &invalidAddressClaim)
@@ -206,7 +78,7 @@ func TestMsgClaim_DoClaim(t *testing.T) {
 
 	// already claimed in current period
 	blockHeight, iScore = DoClaim(ctx, &alreadyClaimedInCurrentPeriodClaim)
-	assert.Equal(t, dbContent1.BlockHeight, blockHeight)
+	assert.Equal(t, uint64(0), blockHeight)
 	assert.Nil(t, iScore)
 
 	// update Query DB

--- a/core/msg_test.go
+++ b/core/msg_test.go
@@ -47,7 +47,7 @@ func TestMsg_DoQuery(t *testing.T) {
 	assert.Equal(t, 0, dbContent0.IScore.Cmp(&resp.IScore.Int))
 
 	// commit to claim DB
-	ctx.preCommit.writeClaimToDB(ctx, claim.BlockHeight, claim.BlockHash)
+	writePreCommitToClaimDB(ctx.DB.getPreCommitDB(), ctx.DB.getClaimDB(), claim.BlockHeight, claim.BlockHash)
 
 	// Query to claimed Account after commit
 	resp = DoQuery(ctx, *address)


### PR DESCRIPTION
- add PreCommit struct to manage preCommit data
- write to preCommit DB when receive CLAIM message
- confirm preCommit data in preCommit DB when receive COMMIT_CLAIM message
- read confirmed preCommit data from preCommit DB and write claim data to claim DB when receive COMMIT_BLOCK message