### PR TITLE
IS-916: fix beta2 calculation bug

### DIFF
--- a/core/context.go
+++ b/core/context.go
@@ -19,6 +19,10 @@ const (
 	AccountDBNameFormat = "calculate_%d_%d_%d"
 	BackupDBNamePrefix  = "backup_"
 	BackupDBNameFormat  = BackupDBNamePrefix + "%d_%d"	// CalcBH_accountDBIndex
+
+	Revision8 uint64    = 8
+	RevisionMin = Revision8
+	RevisionMax = Revision8
 )
 
 type IScoreDB struct {


### PR DESCRIPTION
- If P-Rep get penalty or unregister, blockHeight in the calculate DB is corrupted while calculating beta2.
- do not update blockHeight while calculating beta2
- applies to Revision 8